### PR TITLE
Add RFC comment to pair.proto

### DIFF
--- a/pair.proto
+++ b/pair.proto
@@ -34,12 +34,12 @@ message PairRequestMessage {
   SenderKind senderKind = 1;
 
   /*
-   * public key (PEM encoded) used for signing messages from the initiator;
+   * public key (PEM encoded - RFC 7468) used for signing messages from the initiator
    */
   string publicSignatureKey = 3;
 
   /*
-   * public key (PEM encoded) used for encrypting messages to the initiator;
+   * public key (PEM encoded - RFC 7468) used for encrypting messages to the initiator
    */
   string publicEncryptionKey = 4;
 


### PR DESCRIPTION
Issue #5. Reference RFC 7468 in the comments about PEM encoding. 