### PR TITLE
Fix: broken derecsecret.proto/protoc

### DIFF
--- a/derecsecret.proto
+++ b/derecsecret.proto
@@ -19,6 +19,9 @@ syntax = "proto3";
 import "result.proto";
 import "parameterrange.proto";
 import "google/protobuf/timestamp.proto";
+
+package org.derecalliance.derec.protobuf;
+
 /*
  * This is the sharer's data to be encrypted and stored with the helpers.
  * It includes both secret data and various pieces of secret metadata.


### PR DESCRIPTION
fix: broken derecsecret.proto that fails to compile with protoc
Fix: https://github.com/derecalliance/protobufs/issues/37
